### PR TITLE
#74 - Create a Badge Component

### DIFF
--- a/src/components/primitive/badge/badge.component.props.ts
+++ b/src/components/primitive/badge/badge.component.props.ts
@@ -1,0 +1,18 @@
+import { TextComponentProps } from 'components/primitive/text/text.component.props';
+/**
+ * Success Danger Warning
+ */
+
+import { BoxComponentProps } from '..';
+
+export enum Variant {
+  success = 'success',
+  danger = 'danger',
+  warning = 'warning',
+}
+
+export interface BadgeComponentProps extends BoxComponentProps {
+  label: TextComponentProps;
+
+  variant: keyof typeof Variant;
+}

--- a/src/components/primitive/badge/badge.component.props.ts
+++ b/src/components/primitive/badge/badge.component.props.ts
@@ -1,17 +1,22 @@
 import { TextComponentProps } from 'components/primitive/text/text.component.props';
+import { BoxComponentProps } from 'components/primitive/box/box.component.props';
+
 /**
- * Success Danger Warning
+ * Different Variants of Badge Component
  */
-
-import { BoxComponentProps } from '..';
-
 export enum Variant {
   success = 'success',
   danger = 'danger',
 }
 
 export interface BadgeComponentProps extends BoxComponentProps {
+  /**
+   * label for Text Component
+   */
   label: TextComponentProps;
 
+  /**
+   * option to use diffent variants. Success is the default variant.
+   */
   variant: keyof typeof Variant;
 }

--- a/src/components/primitive/badge/badge.component.props.ts
+++ b/src/components/primitive/badge/badge.component.props.ts
@@ -8,7 +8,6 @@ import { BoxComponentProps } from '..';
 export enum Variant {
   success = 'success',
   danger = 'danger',
-  warning = 'warning',
 }
 
 export interface BadgeComponentProps extends BoxComponentProps {

--- a/src/components/primitive/badge/badge.component.styles.ts
+++ b/src/components/primitive/badge/badge.component.styles.ts
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
-import { Box, Text } from '..';
+import { Box, Text } from 'components/primitive';
 
+/**
+ * Base styles for Badge Component.
+ */
 export const BaseBadge = styled(Box)`
-  height: 3.5rem;
+  height: 3.3rem !important;
   width: fit-content;
   padding: 1.2rem 0.6rem !important;
   min-width: 10.5rem !important;
@@ -12,18 +15,23 @@ export const BaseBadge = styled(Box)`
 `;
 
 /**
- * Success Danger Warning
+ * Style for SuccessBadge.
  */
 export const SuccessBadge = styled(BaseBadge)`
-  /* background-color: ${({ theme: { colors } }) => colors.primary} !important; */
-  background-color: rgba(73, 179, 147, 0.1);
-  color: #49b393 !important;
+  background-color: ${({ theme: { colors } }) => colors.successLighter} !important;
 `;
 
+/**
+ * Style for DangerBadge.
+ */
 export const DangerBadge = styled(BaseBadge)`
-  background-color: rgba(255, 162, 136, 0.1);
+  background-color: ${({ theme: { colors } }) => colors.errorLighter} !important;
 `;
 
-export const ButtonText = styled(Text)`
+/**
+ * Default styles for BadgeText.
+ */
+export const BadgeText = styled(Text)`
   color: ${({ theme: { colors } }) => colors.white};
+  font-size: 1.4rem;
 `;

--- a/src/components/primitive/badge/badge.component.styles.ts
+++ b/src/components/primitive/badge/badge.component.styles.ts
@@ -8,21 +8,20 @@ export const BaseBadge = styled(Box)`
   min-width: 10.5rem !important;
   border-radius: 0.4rem;
   border: none;
+  align-content: center !important;
 `;
 
 /**
  * Success Danger Warning
  */
 export const SuccessBadge = styled(BaseBadge)`
-  background-color: ${({ theme: { colors } }) => colors.primary} !important;
+  /* background-color: ${({ theme: { colors } }) => colors.primary} !important; */
+  background-color: rgba(73, 179, 147, 0.1);
+  color: #49b393 !important;
 `;
 
 export const DangerBadge = styled(BaseBadge)`
-  background-color: ${({ theme: { colors } }) => colors.primary} !important;
-`;
-
-export const WarningBadge = styled(BaseBadge)`
-  background-color: ${({ theme: { colors } }) => colors.primary} !important;
+  background-color: rgba(255, 162, 136, 0.1);
 `;
 
 export const ButtonText = styled(Text)`

--- a/src/components/primitive/badge/badge.component.styles.ts
+++ b/src/components/primitive/badge/badge.component.styles.ts
@@ -32,6 +32,6 @@ export const DangerBadge = styled(BaseBadge)`
  * Default styles for BadgeText.
  */
 export const BadgeText = styled(Text)`
-  color: ${({ theme: { colors } }) => colors.white};
+  color: ${({ theme: { colors } }) => colors.successLight};
   font-size: 1.4rem;
 `;

--- a/src/components/primitive/badge/badge.component.styles.ts
+++ b/src/components/primitive/badge/badge.component.styles.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { Box, Text } from '..';
+
+export const BaseBadge = styled(Box)`
+  height: 3.5rem;
+  width: fit-content;
+  padding: 1.2rem 0.6rem !important;
+  min-width: 10.5rem !important;
+  border-radius: 0.4rem;
+  border: none;
+`;
+
+/**
+ * Success Danger Warning
+ */
+export const SuccessBadge = styled(BaseBadge)`
+  background-color: ${({ theme: { colors } }) => colors.primary} !important;
+`;
+
+export const DangerBadge = styled(BaseBadge)`
+  background-color: ${({ theme: { colors } }) => colors.primary} !important;
+`;
+
+export const WarningBadge = styled(BaseBadge)`
+  background-color: ${({ theme: { colors } }) => colors.primary} !important;
+`;
+
+export const ButtonText = styled(Text)`
+  color: ${({ theme: { colors } }) => colors.white};
+`;

--- a/src/components/primitive/badge/badge.component.tsx
+++ b/src/components/primitive/badge/badge.component.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import { BadgeComponentProps, Variant } from './badge.component.props';
+import { ButtonText, DangerBadge, SuccessBadge, WarningBadge } from './badge.component.styles';
+
+export const Badge: React.FC<BadgeComponentProps> = (props) => {
+  const { variant = 'success', label, ...rest } = props;
+
+  const getVariant = (variant: Variant = Variant.success) => {
+    let BadgeComponent;
+    switch (variant) {
+      case Variant.success:
+        BadgeComponent = SuccessBadge;
+        break;
+
+      case Variant.warning:
+        BadgeComponent = WarningBadge;
+        break;
+      case Variant.danger:
+        BadgeComponent = DangerBadge;
+        break;
+
+      default:
+        BadgeComponent = SuccessBadge;
+    }
+    return BadgeComponent;
+  };
+
+  const StyledBadge = getVariant(Variant[variant]);
+
+  const StyledBadgeComponent = styled(StyledBadge)`
+    background: ${({ color, theme: { colors } }) => color && colors[color]} !important;
+  `;
+
+  return (
+    // @ts-ignore - No overload matched this call.
+    <StyledBadgeComponent row vCenter hCenter {...rest}>
+      <ButtonText {...label} />
+    </StyledBadgeComponent>
+  );
+};

--- a/src/components/primitive/badge/badge.component.tsx
+++ b/src/components/primitive/badge/badge.component.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { BadgeComponentProps, Variant } from './badge.component.props';
-import { ButtonText, DangerBadge, SuccessBadge, WarningBadge } from './badge.component.styles';
+import { ButtonText, DangerBadge, SuccessBadge } from './badge.component.styles';
 
 export const Badge: React.FC<BadgeComponentProps> = (props) => {
-  const { variant = 'success', label, ...rest } = props;
+  const { variant, label, ...rest } = props;
 
   const getVariant = (variant: Variant = Variant.success) => {
     let BadgeComponent;
@@ -12,9 +12,6 @@ export const Badge: React.FC<BadgeComponentProps> = (props) => {
         BadgeComponent = SuccessBadge;
         break;
 
-      case Variant.warning:
-        BadgeComponent = WarningBadge;
-        break;
       case Variant.danger:
         BadgeComponent = DangerBadge;
         break;

--- a/src/components/primitive/badge/badge.component.tsx
+++ b/src/components/primitive/badge/badge.component.tsx
@@ -4,6 +4,8 @@ import { BadgeText, DangerBadge, SuccessBadge } from './badge.component.styles';
 export const Badge: React.FC<BadgeComponentProps> = (props) => {
   const { variant, label, ...rest } = props;
 
+  const textColor = variant === 'danger' ? 'errorLight' : 'successLight';
+
   const getVariant = (variant: Variant = Variant.success) => {
     let badgeComponent;
 
@@ -28,7 +30,7 @@ export const Badge: React.FC<BadgeComponentProps> = (props) => {
   return (
     // @ts-ignore - No overload matched this call.
     <StyledBadgeComponent row vCenter hCenter {...rest}>
-      <BadgeText {...label} />
+      <BadgeText color={textColor} {...label} />
     </StyledBadgeComponent>
   );
 };

--- a/src/components/primitive/badge/badge.component.tsx
+++ b/src/components/primitive/badge/badge.component.tsx
@@ -1,37 +1,34 @@
-import styled from 'styled-components';
 import { BadgeComponentProps, Variant } from './badge.component.props';
-import { ButtonText, DangerBadge, SuccessBadge } from './badge.component.styles';
+import { BadgeText, DangerBadge, SuccessBadge } from './badge.component.styles';
 
 export const Badge: React.FC<BadgeComponentProps> = (props) => {
   const { variant, label, ...rest } = props;
 
   const getVariant = (variant: Variant = Variant.success) => {
-    let BadgeComponent;
+    let badgeComponent;
+
     switch (variant) {
       case Variant.success:
-        BadgeComponent = SuccessBadge;
+        badgeComponent = SuccessBadge;
         break;
 
       case Variant.danger:
-        BadgeComponent = DangerBadge;
+        badgeComponent = DangerBadge;
         break;
 
       default:
-        BadgeComponent = SuccessBadge;
+        badgeComponent = SuccessBadge;
     }
-    return BadgeComponent;
+
+    return badgeComponent;
   };
 
-  const StyledBadge = getVariant(Variant[variant]);
-
-  const StyledBadgeComponent = styled(StyledBadge)`
-    background: ${({ color, theme: { colors } }) => color && colors[color]} !important;
-  `;
+  const StyledBadgeComponent = getVariant(Variant[variant]);
 
   return (
     // @ts-ignore - No overload matched this call.
     <StyledBadgeComponent row vCenter hCenter {...rest}>
-      <ButtonText {...label} />
+      <BadgeText {...label} />
     </StyledBadgeComponent>
   );
 };

--- a/src/components/primitive/index.ts
+++ b/src/components/primitive/index.ts
@@ -32,4 +32,6 @@ export * from './loader/loader.component';
 
 export * from './create-card/create-card.component';
 
+export * from './badge/badge.component';
+
 export * from 'react-grid-system';

--- a/src/themes/colors.ts
+++ b/src/themes/colors.ts
@@ -10,8 +10,10 @@ export const colors = {
   textLighter: palette.greyLighter, //placeholder and borders
   success: palette.green,
   successLight: palette.greenLight, //text
+  successLighter: palette.greenTransparent, // Transparent Backgrounds
   error: palette.red,
   errorLight: palette.redLight, //text
+  errorLighter: palette.redTransparent,
   link: palette.blueLight,
   warning: palette.yellow,
   warningLight: palette.yellowLight, //text

--- a/src/themes/palette.ts
+++ b/src/themes/palette.ts
@@ -10,18 +10,20 @@ export const palette = {
   blueLight: 'rgba(84, 82, 246, 0.1)', //alert, icon backgrounds
   blueTransparent: 'rgba(84, 82, 246, 0.1)', // NavLink active color
   green: '#2ba745',
-  greenLight: '#0f5132', //green text color
+  greenLight: '#49B393', //green text color
   greenLighter: '#d1e7dd', //alert bg
   greenLightest: '#badbcc', //for border
+  greenTransparent: 'rgba(73, 179, 147, 0.1)',
   greenDark: '#065f43', //for icons
   yellow: '#ffc107', //default yellow color
   yellowLight: '#664d03', //for text
   yellowLighter: '#fff3cd', //alert bg
   yellowLightest: '#ffecb5', //border
   red: '#dc3545',
-  redLight: '#842029', //text color on alert bg
+  redLight: '#FFA288', //text color on alert bg
   redLighter: '#f8d7da', // alert bg
   redLightest: '#f5c2c7', //borders
+  redTransparent: 'rgba(255, 162, 136, 0.1)',
   grey: '#28293d', // default dark headings
   greyLight: '#555770', // light heading, body text
   greyLighter: '#8E90A6', //for placeholders and secondary button


### PR DESCRIPTION
## Description

- [x] Adds Reusable Badge component
- [x] Replaced new error and success color in palette file.

### Usage
```
      <Badge label={{ text: 'Claimed', color: 'successLight' }} variant='success' />
      <br />
      <Badge label={{ text: 'Pending', color: 'errorLight' }} variant='danger' />
```

## Screenshot
![image](https://user-images.githubusercontent.com/30016242/144102835-8fad4448-0c2d-4457-8485-26879536dcc1.png)

## Platform tested
- [x] Large
- [x] Tablet
- [x] Mobile
