### PR TITLE
#86 - Create a reusable StatsCard

### DIFF
--- a/src/components/primitive/index.ts
+++ b/src/components/primitive/index.ts
@@ -34,6 +34,8 @@ export * from './loader/loader.component';
 
 export * from './create-card/create-card.component';
 
+export * from './stats-card/stats-card.component';
+
 export * from './badge/badge.component';
 
 export * from 'react-grid-system';

--- a/src/components/primitive/stats-card/stats-card.component.props.ts
+++ b/src/components/primitive/stats-card/stats-card.component.props.ts
@@ -1,0 +1,8 @@
+import { TextComponentProps } from './../text/text.component.props';
+import { AvatarComponentProps } from './../avatar/avatar.component.props';
+
+export interface StatsComponentProps {
+  iconName: AvatarComponentProps;
+  heading: TextComponentProps;
+  count?: TextComponentProps;
+}

--- a/src/components/primitive/stats-card/stats-card.component.props.ts
+++ b/src/components/primitive/stats-card/stats-card.component.props.ts
@@ -2,7 +2,18 @@ import { TextComponentProps } from './../text/text.component.props';
 import { AvatarComponentProps } from './../avatar/avatar.component.props';
 
 export interface StatsComponentProps {
+  /**
+   * Name of the Icon.
+   */
   iconName: AvatarComponentProps;
+
+  /**
+   * Headline for Stats Card.
+   */
   heading: TextComponentProps;
+
+  /**
+   * Count for Stats Card.
+   */
   count?: TextComponentProps;
 }

--- a/src/components/primitive/stats-card/stats-card.component.styles.ts
+++ b/src/components/primitive/stats-card/stats-card.component.styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+/**
+ * Styles for Stats Container.
+ */
+export const StatsContainer = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  width: fit-content;
+`;
+
+/**
+ * Styles for CountContainer.
+ */
+export const CountContainer = styled.span`
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;

--- a/src/components/primitive/stats-card/stats-card.component.tsx
+++ b/src/components/primitive/stats-card/stats-card.component.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { Avatar, Text } from '..';
+import { StatsComponentProps } from './stats-card.component.props';
+
+export const StatsContainer = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  width: fit-content;
+`;
+export const CountContainer = styled.span`
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+export const StatsCard: React.FC<StatsComponentProps> = (props) => {
+  const { heading, count, iconName } = props;
+
+  return (
+    <StatsContainer>
+      <Avatar size='large' flat {...iconName} />
+      <CountContainer>
+        <Text variant='small' color='textLight' {...heading} />
+        <Text variant='contentHeader' {...count} />
+      </CountContainer>
+    </StatsContainer>
+  );
+};

--- a/src/components/primitive/stats-card/stats-card.component.tsx
+++ b/src/components/primitive/stats-card/stats-card.component.tsx
@@ -1,17 +1,7 @@
-import styled from 'styled-components';
-import { Avatar, Text } from '..';
+import { Avatar, Text } from 'components/primitive';
 import { StatsComponentProps } from './stats-card.component.props';
+import { StatsContainer, CountContainer } from './stats-card.component.styles';
 
-export const StatsContainer = styled.div`
-  display: flex;
-  gap: 1.6rem;
-  width: fit-content;
-`;
-export const CountContainer = styled.span`
-  display: inline-flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
 export const StatsCard: React.FC<StatsComponentProps> = (props) => {
   const { heading, count, iconName } = props;
 


### PR DESCRIPTION
## Description
- [x] Adds reusable stats card.

## Usage 

```
 <StatsCard
     heading={{ text: 'Safes you are Guarding' }}
     count={{ text: '02' }}
     iconName={{ name: 'guarding' }}
  />
```

## Screenshot

![image](https://user-images.githubusercontent.com/30016242/146772643-7b16b74c-bef4-4d77-b162-6f4f8e05ba8d.png)



## Platform tested
- [x] Web
- [x] Tablet
- [x] Mobile
